### PR TITLE
Support Local Mappings Provider

### DIFF
--- a/starmap_client/providers/__init__.py
+++ b/starmap_client/providers/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+from starmap_client.providers.base import StarmapProvider  # noqa: F401
+from starmap_client.providers.memory import InMemoryMapProvider  # noqa: F401

--- a/starmap_client/providers/base.py
+++ b/starmap_client/providers/base.py
@@ -1,0 +1,35 @@
+from abc import ABC, abstractmethod
+from typing import Any, Dict, List, Optional
+
+from starmap_client.models import QueryResponse
+
+
+class StarmapProvider(ABC):
+    """Define the interface for a local mappings provider."""
+
+    @abstractmethod
+    def query(self, params: Dict[str, Any]) -> Optional[QueryResponse]:
+        """Retrieve the mapping without using the server.
+
+        It relies in the local provider to retrieve the correct mapping
+        according to the parameters.
+
+        Args:
+            params (dict):
+                The request params to retrieve the mapping.
+        Returns:
+            The requested mapping when found.
+        """
+
+    @abstractmethod
+    def list_content(self) -> List[QueryResponse]:
+        """Return a list with all stored QueryResponse objects."""
+
+    @abstractmethod
+    def store(self, query_response: QueryResponse) -> None:
+        """Store a single query_response into the local provider.
+
+        Args:
+            query_response (query_response):
+                The object to store.
+        """

--- a/starmap_client/providers/memory.py
+++ b/starmap_client/providers/memory.py
@@ -1,0 +1,68 @@
+from typing import Any, Dict, List, Optional
+
+from starmap_client.models import QueryResponse
+from starmap_client.providers.base import StarmapProvider
+from starmap_client.providers.utils import get_image_name
+
+
+class InMemoryMapProvider(StarmapProvider):
+    """Provide in memory (RAM) QueryResponse mapping objects."""
+
+    def __init__(
+        self, map_responses: Optional[List[QueryResponse]] = None, *args, **kwargs
+    ) -> None:
+        """Crete a new InMemoryMapProvider object.
+
+        Args:
+            map_responses (list, optional)
+                List of QueryResponse objects to load into memory. They will be
+                used by query to fetch the correct response based on name
+                and workflow.
+        """
+        self._separator = str(kwargs.pop("separator", "+"))
+        self._content: Dict[str, QueryResponse] = {}
+        super(StarmapProvider, self).__init__()
+        self._boostrap(map_responses)
+
+    def _boostrap(self, map_responses: Optional[List[QueryResponse]]) -> None:
+        """Initialize the internal content dictionary.
+
+        Args:
+            map_responses (list, optional)
+                List of QueryResponse objects to load into memory.
+        """
+        if not map_responses:
+            return None
+
+        # The in memory content is made of a combination of name and workflow
+        for map in map_responses:
+            key = f"{map.name}{self._separator}{map.workflow.value}"
+            self._content[key] = map
+
+    def list_content(self) -> List[QueryResponse]:
+        """Return a list of stored content."""
+        return list(self._content.values())
+
+    def store(self, query_response: QueryResponse) -> None:
+        """Store/replace a single QueryResponse object.
+
+        Args:
+            query_response (query_response):
+                The object to store.
+        """
+        key = f"{query_response.name}{self._separator}{query_response.workflow.value}"
+        self._content[key] = query_response
+
+    def query(self, params: Dict[str, Any]) -> Optional[QueryResponse]:
+        """Return the mapping from memory according to the received params.
+
+        Args:
+            params (dict):
+                The request params to retrieve the mapping.
+        Returns:
+            The requested mapping when found.
+        """
+        name = params.get("name") or get_image_name(params.get("image"))
+        workflow = str(params.get("workflow", ""))
+        search_key = f"{name}{self._separator}{workflow}"
+        return self._content.get(search_key)

--- a/starmap_client/providers/utils.py
+++ b/starmap_client/providers/utils.py
@@ -1,0 +1,77 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# The functions below were adapted from Kobo's RPMLib:
+# https://github.com/release-engineering/kobo/blob/master/kobo/rpmlib.py
+import logging
+from typing import Dict, Optional, Tuple
+
+log = logging.getLogger(__name__)
+
+
+def split_nvr_epoch(nvre: str) -> Tuple[str, str]:
+    """
+    Split nvre to N-V-R and E.
+
+    :param nvre: E:N-V-R or N-V-R:E string
+    :return: (N-V-R, E)
+    """
+    if ":" in nvre:
+        log.debug("Splitting NVR and Epoch")
+        if nvre.count(":") != 1:
+            raise RuntimeError(f"Invalid NVRE: {nvre}")
+
+        nvr, epoch = nvre.rsplit(":", 1)
+        if "-" in epoch:
+            if "-" not in nvr:
+                # switch nvr with epoch
+                nvr, epoch = epoch, nvr
+            else:
+                # it's probably N-E:V-R format, handle it after the split
+                nvr, epoch = nvre, ""
+    else:
+        log.debug("No epoch to split")
+        nvr, epoch = nvre, ""
+
+    return nvr, epoch
+
+
+def parse_nvr(nvre: str) -> Dict[str, str]:
+    """
+    Split N-V-R into a dictionary.
+
+    :param nvre: N-V-R:E, E:N-V-R or N-E:V-R string
+    :return: {name, version, release, epoch}
+    """
+    log.debug("Parsing NVR")
+    if "/" in nvre:
+        nvre = nvre.split("/")[-1]
+
+    nvr, epoch = split_nvr_epoch(nvre)
+
+    log.debug("Splitting NVR parts")
+    nvr_parts = nvr.rsplit("-", 2)
+    if len(nvr_parts) != 3:
+        raise RuntimeError(f"Invalid NVR: {nvr}")
+
+    # parse E:V
+    if epoch == "" and ":" in nvr_parts[1]:
+        log.debug("Parsing E:V")
+        epoch, nvr_parts[1] = nvr_parts[1].split(":", 1)
+
+    # check if epoch is empty or numeric
+    if epoch != "":
+        try:
+            int(epoch)
+        except ValueError:
+            raise RuntimeError(f"Invalid epoch '{epoch}' in '{nvr}'")
+
+    result = dict(zip(["name", "version", "release"], nvr_parts))
+    result["epoch"] = epoch
+    return result
+
+
+def get_image_name(image: Optional[str]) -> str:
+    """Retrieve the name from NVR."""
+    if not image:
+        return ""
+    nvr = parse_nvr(image)
+    return nvr.get("name", "")

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -10,6 +10,7 @@ from requests.exceptions import HTTPError
 
 from starmap_client import StarmapClient
 from starmap_client.models import Destination, Mapping, Policy, QueryResponse
+from starmap_client.providers import InMemoryMapProvider
 
 
 def load_json(json_file: str) -> Any:
@@ -56,6 +57,17 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, QueryResponse.from_json(load_json(fpath)))
 
+    def test_in_memory_query_image(self):
+        fpath = "tests/data/query/valid_quer1.json"
+        data = [QueryResponse.from_json(load_json(fpath))]
+        provider = InMemoryMapProvider(data)
+
+        self.svc = StarmapClient("https://test.starmap.com", api_version="v1", provider=provider)
+
+        res = self.svc.query_image("sample-policy-1.0-1.raw.xz")
+        self.mock_session.get.assert_not_called()
+        self.assertEqual(res, data[0])
+
     def test_query_image_not_found(self):
         self.mock_session.get.return_value = self.mock_resp_not_found
 
@@ -82,6 +94,17 @@ class TestStarmapClient(TestCase):
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, QueryResponse.from_json(load_json(fpath)))
+
+    def test_in_memory_query_image_by_name(self):
+        fpath = "tests/data/query/valid_quer1.json"
+        data = [QueryResponse.from_json(load_json(fpath))]
+        provider = InMemoryMapProvider(data)
+
+        self.svc = StarmapClient("https://test.starmap.com", api_version="v1", provider=provider)
+
+        res = self.svc.query_image_by_name(name="sample-policy")
+        self.mock_session.get.assert_not_called()
+        self.assertEqual(res, data[0])
 
     def test_query_image_by_name_version(self):
         fpath = "tests/data/query/valid_quer1.json"

--- a/tests/test_providers/conftest.py
+++ b/tests/test_providers/conftest.py
@@ -1,0 +1,75 @@
+from typing import Any, Dict
+
+import pytest
+
+from starmap_client.models import QueryResponse
+
+
+@pytest.fixture
+def qr1() -> Dict[str, Any]:
+    return {
+        "mappings": {
+            "aws-na": [
+                {
+                    "architecture": "x86_64",
+                    "destination": "ffffffff-ffff-ffff-ffff-ffffffffffff",
+                    "overwrite": True,
+                    "restrict_version": False,
+                    "meta": {"tag1": "aws-na-value1", "tag2": "aws-na-value2"},
+                    "tags": {"key1": "value1", "key2": "value2"},
+                }
+            ],
+            "aws-emea": [
+                {
+                    "architecture": "x86_64",
+                    "destination": "00000000-0000-0000-0000-000000000000",
+                    "overwrite": True,
+                    "restrict_version": False,
+                    "meta": {"tag1": "aws-emea-value1", "tag2": "aws-emea-value2"},
+                    "tags": {"key3": "value3", "key4": "value4"},
+                }
+            ],
+        },
+        "name": "sample-product",
+        "workflow": "stratosphere",
+    }
+
+
+@pytest.fixture
+def qr2() -> Dict[str, Any]:
+    return {
+        "mappings": {
+            "aws-na": [
+                {
+                    "architecture": "x86_64",
+                    "destination": "test-dest-1",
+                    "overwrite": True,
+                    "restrict_version": False,
+                    "meta": {"tag1": "aws-na-value1", "tag2": "aws-na-value2"},
+                    "tags": {"key1": "value1", "key2": "value2"},
+                }
+            ],
+            "aws-emea": [
+                {
+                    "architecture": "x86_64",
+                    "destination": "test-dest-2",
+                    "overwrite": True,
+                    "restrict_version": False,
+                    "meta": {"tag1": "aws-emea-value1", "tag2": "aws-emea-value2"},
+                    "tags": {"key3": "value3", "key4": "value4"},
+                }
+            ],
+        },
+        "name": "sample-product",
+        "workflow": "community",
+    }
+
+
+@pytest.fixture
+def qr1_object(qr1) -> QueryResponse:
+    return QueryResponse.from_json(qr1)
+
+
+@pytest.fixture
+def qr2_object(qr2) -> QueryResponse:
+    return QueryResponse.from_json(qr2)

--- a/tests/test_providers/test_memory.py
+++ b/tests/test_providers/test_memory.py
@@ -1,0 +1,58 @@
+from typing import Any, Dict, Optional
+
+import pytest
+
+from starmap_client.models import QueryResponse
+from starmap_client.providers import InMemoryMapProvider
+
+
+class TestInMemoryMapProvider:
+
+    def test_list_content(self, qr1_object: QueryResponse, qr2_object: QueryResponse) -> None:
+        data = [qr1_object, qr2_object]
+
+        provider = InMemoryMapProvider(map_responses=data)
+
+        assert provider.list_content() == data
+
+    def test_store(self, qr1_object: QueryResponse, qr2_object: QueryResponse) -> None:
+        provider = InMemoryMapProvider()
+
+        assert provider.list_content() == []
+
+        provider.store(qr1_object)
+
+        assert provider.list_content() == [qr1_object]
+
+        provider.store(qr2_object)
+
+        assert provider.list_content() == [qr1_object, qr2_object]
+
+    @pytest.mark.parametrize(
+        "params, expected",
+        [
+            (
+                {"name": "sample-product", "version": "8.0", "workflow": "stratosphere"},
+                'qr1_object',
+            ),
+            ({"name": "sample-product", "version": "8.1", "workflow": "community"}, 'qr2_object'),
+            ({"name": "another-product", "version": "8.2", "workflow": "stratosphere"}, None),
+            ({"name": "another-product", "version": "8.2", "workflow": "community"}, None),
+        ],
+    )
+    def test_query(
+        self,
+        params: Dict[str, Any],
+        expected: Optional[str],
+        qr1_object: QueryResponse,
+        qr2_object: QueryResponse,
+        request: pytest.FixtureRequest,
+    ) -> None:
+        data = [qr1_object, qr2_object]
+        provider = InMemoryMapProvider(data)
+
+        if expected is not None:
+            expected = request.getfixturevalue(expected)
+
+        qr = provider.query(params)
+        assert qr == expected

--- a/tests/test_providers/test_utils.py
+++ b/tests/test_providers/test_utils.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# The tests below were adapted from Kobo's RPMLib:
+# https://github.com/release-engineering/kobo/blob/master/tests/test_rpmlib.py
+import unittest
+
+from starmap_client.providers.utils import get_image_name, parse_nvr
+
+
+class TestNVR(unittest.TestCase):
+    def test_parse_nvr_success(self) -> None:
+        self.assertEqual(
+            parse_nvr("net-snmp-5.3.2.2-5.el5"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch=""),
+        )
+        self.assertEqual(
+            parse_nvr("1:net-snmp-5.3.2.2-5.el5"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("net-snmp-1:5.3.2.2-5.el5"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("net-snmp-5.3.2.2-5.el5:1"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("/net-snmp-5.3.2.2-5.el5:1"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("/1:net-snmp-5.3.2.2-5.el5"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("foo/net-snmp-5.3.2.2-5.el5:1"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("foo/1:net-snmp-5.3.2.2-5.el5"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("/foo/bar/net-snmp-5.3.2.2-5.el5:1"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+        self.assertEqual(
+            parse_nvr("/foo/bar/1:net-snmp-5.3.2.2-5.el5"),
+            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        )
+
+        # test for name which contains the version number and a dash
+        self.assertEqual(
+            parse_nvr("openmpi-1.10-1.10.2-2.el6"),
+            dict(name="openmpi-1.10", version="1.10.2", release="2.el6", epoch=""),
+        )
+
+    def test_parse_nvr_invalid(self) -> None:
+        self.assertRaises(RuntimeError, parse_nvr, "net-snmp")
+        self.assertRaises(RuntimeError, parse_nvr, "net-snmp-5.3.2.2-1:5.el5")
+        self.assertRaises(RuntimeError, parse_nvr, "1:net-snmp-5.3.2.2-5.el5:1")
+        self.assertRaises(RuntimeError, parse_nvr, "1:net-snmp-1:5.3.2.2-5.el5")
+        self.assertRaises(RuntimeError, parse_nvr, "net-snmp-1:5.3.2.2-5.el5:1")
+        self.assertRaises(RuntimeError, parse_nvr, "1:net-snmp-1:5.3.2.2-5.el5:1")
+
+    def test_get_image_name(self) -> None:
+        self.assertEqual(get_image_name("net-snmp-5.3.2.2-5.el5"), "net-snmp")
+        self.assertEqual(get_image_name("1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
+        self.assertEqual(get_image_name("net-snmp-1:5.3.2.2-5.el5"), "net-snmp")
+        self.assertEqual(get_image_name("net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
+        self.assertEqual(get_image_name("/net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
+        self.assertEqual(get_image_name("/1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
+        self.assertEqual(get_image_name("foo/net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
+        self.assertEqual(get_image_name("foo/1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
+        self.assertEqual(get_image_name("/foo/bar/net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
+        self.assertEqual(get_image_name("/foo/bar/1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
+        self.assertEqual(
+            get_image_name("openmpi-1.10-1.10.2-2.el6"),
+            "openmpi-1.10",
+        )
+        self.assertEqual(get_image_name(None), "")


### PR DESCRIPTION
This PR introduces the concept of `providers` which works as a way  to store and retrieve `QueryResponse` objects from a local environment instead of having to request it to the server.
    
It also implements the first provider named `InMemoryMapProvider` which aims to provide an "offline" way to store existing `QueryResponse` objects in memory and use them to provide mappings. Then, whenever an object exists "offline" (in memory) it will be returned instead of  having to request it from StArMap server.

Finally, it changes the `StarmapClient` by adding a new constructor argument named `provider`, which when set with a `StArMapProvider` will use it to query image image first and only proceed to query the server whenever the mapping is not found in the local provider.
    
Refers to SPSTRAT-325
