### PR TITLE
Allow using StarmapClient Offline

### DIFF
--- a/docs/client/client.rst
+++ b/docs/client/client.rst
@@ -1,13 +1,9 @@
 Client
 ======
 
-Define the client classes to communicate with StArMap over HTTPS.
+Define the client classes to communicate with StArMap through a `session`_.
 
+.. include:: usage.rst
+.. include:: implementation.rst
 
-.. autoclass:: starmap_client.StarmapClient
-   :members:
-   :special-members: __init__
-
-.. autoclass:: starmap_client.session.StarmapSession
-   :members:
-   :special-members: __init__
+.. _session: ../session/session.html

--- a/docs/client/implementation.rst
+++ b/docs/client/implementation.rst
@@ -1,0 +1,5 @@
+Implementation
+--------------
+.. autoclass:: starmap_client.StarmapClient
+   :members:
+   :special-members: __init__

--- a/docs/client/usage.rst
+++ b/docs/client/usage.rst
@@ -1,0 +1,90 @@
+Usage
+-----
+
+The :class:`~starmap_client.StarmapClient` can be used to query the StArMap service over network and/or
+locally.
+
+In the subsections below you can find how to properly use the client for different
+query use-cases.
+
+Online Usage
+^^^^^^^^^^^^
+
+In this mode the :class:`~starmap_client.StarmapClient` will always request data from the server over the network.
+
+.. code-block:: python
+
+   from starmap_client import StarmapClient
+
+   # Initialize the online client with the URL only
+   client = StarmapClient(url="https://starmap.example.com", api_version="v1")
+
+   # Alternatively you can create the session and inject it
+   from starmap_client.session import StarmapSession
+   session = StarmapSession("https://starmap.example.com", api_version="v1", retries=5, backoff_factor=5.0)
+   client = StarmapClient(session=session)
+   ...
+   # Query
+   client.query_image("sample-product-1.0.0-vhd.xz")
+   client.query_image_by_name(name="sample-product", version="1.0.0")
+
+Note that either ``url`` or ``session`` must be passed to the client to instantiate the object.
+
+
+Offline Usage
+^^^^^^^^^^^^^
+
+In this mode the :class:`~starmap_client.StarmapClient` will always request data from a local `provider`_ instead of using the network.
+
+.. code-block:: python
+
+   import json
+   from starmap_client import StarmapClient
+   from starmap_client.session import StarmapMockSession
+   from starmap_client.models import QueryResponse
+   from starmap_client.providers import InMemoryMapProvider
+
+   # Load the QueryResponse models from somewhere
+   with open("path_to_your_data.json", 'r') as f:
+      qr_data = json.load(f)
+
+   # Create the offline client
+   qr = QueryResponse.from_json(qr_data)
+   responses = [qr]  # in this case it only contains 1 object, but it supports more
+   provider = InMemoryMapProvider(responses)
+   session = StarmapMockSession("fake.starmap.com", "v1")
+   client = StarmapClient(session=session, provider=provider)
+
+   # Query
+   client.query_image("sample-product-1.0.0-vhd.xz")
+   client.query_image_by_name(name="sample-product", version="1.0.0")
+
+Hybrid Usage:
+^^^^^^^^^^^^^
+
+In this mode the :class:`~starmap_client.StarmapClient` will first request data from a local `provider`_ and 
+only proceed to query over network if the local provider doesn't have the requested mapping.
+
+.. code-block:: python
+
+   import json
+   from starmap_client import StarmapClient
+   from starmap_client.models import QueryResponse
+   from starmap_client.providers import InMemoryMapProvider
+
+   # Load the QueryResponse models from somewhere
+   with open("path_to_your_data.json", 'r') as f:
+      qr_data = json.load(f)
+
+   # Create the offline client
+   qr = QueryResponse.from_json(qr_data)
+   responses = [qr]  # in this case it only contains 1 object, but it supports more
+   provider = InMemoryMapProvider(responses)
+   client = StarmapClient(url="https://starmap.example.com", provider=provider)
+
+   # Query
+   client.query_image("sample-product-1.0.0-vhd.xz")
+   client.query_image_by_name(name="sample-product", version="1.0.0")
+
+.. _session: ../session/session.html
+.. _provider: ../provider/provider.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -57,7 +57,7 @@ html_theme = 'alabaster'
 html_theme_options = {
     "description": "A client library to communicate with StArMap",
     "extra_nav_links": {
-        "Source": "https://gitlab.cee.redhat.com/stratosphere/starmap-client",
+        "Source": "https://github.com/release-engineering/starmap-client",
         "Index": "genindex.html",
     },
     # default is 940px which seems to be a little too small to display 88 chars code

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,6 +14,8 @@ A client library to communicate with StArMap.
 
    client/client
    model/models
+   session/session
+   provider/provider
 
 Quick Start
 -----------
@@ -22,10 +24,10 @@ Install starmap_client:
 
 ::
 
-    pip install .
+    pip install starmap-client
 
 In your python code, obtain a :class:`~starmap_client.StarmapClient` instance and
-use it to communicate with `StArMap <https://stratosphere.pages.redhat.com/starmap/>`_:
+use it to communicate with ``StArMap``:
 
 .. code-block:: python
 
@@ -37,7 +39,7 @@ use it to communicate with `StArMap <https://stratosphere.pages.redhat.com/starm
     client = StarmapClient(url="https://starmap.example.com")
 
 
-Then it's possible to use the client object to call any API endpoint from `StArMap <https://stratosphere.pages.redhat.com/starmap/>`_.
+Then it's possible to use the client object to call any API endpoint from ``StArMap``.
 
 .. code-block:: python
 
@@ -60,3 +62,5 @@ Then it's possible to use the client object to call any API endpoint from `StArM
 
     # Get a specific policy by its ID
     policy = client.get_policy(policy_id="426a3eac-8b9d-11ed-90ee-902e165594e8")
+
+.. include:: client/usage.rst

--- a/docs/provider/provider.rst
+++ b/docs/provider/provider.rst
@@ -1,0 +1,19 @@
+Providers
+=========
+
+Define an alternate way to retrieve the query responses.
+
+Interface
+---------
+.. autoclass:: starmap_client.providers.StarmapProvider
+   :members:
+   :special-members: __init__
+
+Implementations
+---------------
+
+Memory Based
+^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: starmap_client.providers.InMemoryMapProvider
+   :members:
+   :special-members: __init__

--- a/docs/session/session.rst
+++ b/docs/session/session.rst
@@ -1,0 +1,26 @@
+Session
+=======
+
+Define a session to communicate with StArMap over HTTPS.
+
+
+Interface
+---------
+.. autoclass:: starmap_client.session.StarmapBaseSession
+   :members:
+   :special-members: __init__
+
+Implementations
+---------------
+
+Network based (Online)
+^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: starmap_client.session.StarmapSession
+   :members:
+   :special-members: __init__
+
+Mock based (Offline)
+^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: starmap_client.session.StarmapMockSession
+   :members:
+   :special-members: __init__

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -325,8 +325,13 @@ requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
     # via
+    #   requests-mock
     #   sphinx
     #   starmap-client (setup.py)
+requests-mock==1.12.1 \
+    --hash=sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563 \
+    --hash=sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401
+    # via starmap-client (setup.py)
 snowballstemmer==2.2.0 \
     --hash=sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1 \
     --hash=sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a

--- a/requirements.txt
+++ b/requirements.txt
@@ -111,6 +111,12 @@ idna==3.7 \
 requests==2.32.3 \
     --hash=sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760 \
     --hash=sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6
+    # via
+    #   requests-mock
+    #   starmap-client (setup.py)
+requests-mock==1.12.1 \
+    --hash=sha256:b1e37054004cdd5e56c84454cc7df12b25f90f382159087f4b6915aaeef39563 \
+    --hash=sha256:e9e12e333b525156e82a3c852f22016b9158220d2f47454de9cae8a77d371401
     # via starmap-client (setup.py)
 urllib3==1.26.19 \
     --hash=sha256:37a0344459b199fce0e80b0d3569837ec6b6937435c5244e7fd73fa6006830f3 \

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     install_requires=[
         'attrs',
         'requests',
+        'requests_mock',
         'urllib3<2.0.0'
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     keywords='stratosphere content artifact mapping cli',
     author='Jonathan Gangi',
     author_email='jgangi@redhat.com',
-    url='https://gitlab.cee.redhat.com/stratosphere/starmap-client',
+    url='https://github.com/release-engineering/starmap-client',
     license='GPLv3+',
     packages=find_packages(exclude=['tests', 'tests.*']),
     include_package_data=True,

--- a/starmap_client/session.py
+++ b/starmap_client/session.py
@@ -1,14 +1,33 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 import logging
+import re
+from abc import ABC, abstractmethod
 from typing import Any, Dict
 
 import requests
+import requests_mock
 from requests.adapters import HTTPAdapter, Retry
 
 log = logging.getLogger(__name__)
 
 
-class StarmapSession(object):
+class StarmapBaseSession(ABC):
+    """Define the interface for the Starmap's session objects."""
+
+    @abstractmethod
+    def get(self, path: str, **kwargs) -> requests.Response:
+        """Perform a GET request on StArMap."""
+
+    @abstractmethod
+    def post(self, path: str, json: Dict[str, Any], **kwargs) -> requests.Response:
+        """Perform a POST request on StArMap."""
+
+    @abstractmethod
+    def put(self, path: str, json: Dict[str, Any], **kwargs) -> requests.Response:
+        """Perform a PUT request on StArMap."""
+
+
+class StarmapSession(StarmapBaseSession):
     """Implement a HTTP(S) session with StArMap."""
 
     def __init__(
@@ -31,6 +50,7 @@ class StarmapSession(object):
             backoff_factor (float, optional)
                 The backoff factor to apply between attempts after the second try
         """
+        super(StarmapSession, self).__init__()
         self.url = url
         self.api_version = api_version
         self.session = requests.Session()
@@ -68,3 +88,51 @@ class StarmapSession(object):
     def put(self, path: str, json: Dict[str, Any], **kwargs) -> requests.Response:
         """Perform a PUT request on StArMap."""
         return self._request("put", path, json=json, **kwargs)
+
+
+class StarmapMockSession(StarmapSession):
+    """Implement a mock session with predefined responses."""
+
+    def __init__(self, url: str, api_version: str, status_code: int = 404, json_data: Any = None):
+        """Create the StarmapMockSession object.
+
+        Args:
+            url (str)
+                The mock server endpoint base URL
+            api_version
+                The mock server API version to call
+            status_code (optional, int)
+                The status code to return on each request
+
+            json_data (optional, any)
+                The JSON data to return on each request
+        """
+        super(StarmapMockSession, self).__init__(url, api_version)
+        self.url = f"mock://{url}"
+        self.api_version = api_version
+        self.status_code = status_code
+        self.json_data = json_data or {}
+        self.session = requests.Session()
+        self.adapter = requests_mock.Adapter()
+        self.session.mount("mock://", self.adapter)
+        self._register_starmap_endpoints()
+
+    def _register_starmap_endpoints(self) -> None:
+        base_url_elements = [self.url, f"/api/{self.api_version}"]
+        base_url = "/".join(arg.strip("/") for arg in base_url_elements)
+        methods = ["GET", "POST", "PUT"]
+        for m in methods:
+            self.register_uri(m, re.compile(f"{base_url}/.*"))  # type: ignore [arg-type]
+
+    def register_uri(self, method: str, uri: str):
+        """Register an URI into the ``requests_mock`` adapter.
+
+        Args:
+            method (str):
+                The HTTP method to register
+            uri:
+                The URI to register
+        """
+        self.adapter.register_uri(
+            method, url=uri, status_code=self.status_code, json=self.json_data
+        )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,6 +1,6 @@
 from unittest import TestCase, mock
 
-from starmap_client.session import StarmapSession
+from starmap_client.session import StarmapMockSession, StarmapSession
 
 
 class TestStarmapSession(TestCase):
@@ -38,3 +38,35 @@ class TestStarmapSession(TestCase):
         data = {"foo": "bar"}
         self.session.put("/foo", json=data)
         self._assert_requested_with(method="put", path="foo", json=data)
+
+
+class TestMockSession(TestCase):
+    def setUp(self):
+        self.starmap_url = "test.starmap.com"
+        self.starmap_api_version = "v1"
+        self.status_code = 404
+        self.json = {}
+        self.session = StarmapMockSession(
+            url=self.starmap_url,
+            api_version=self.starmap_api_version,
+            status_code=self.status_code,
+            json_data=self.json,
+        )
+
+    def _assert_response(self, response):
+        assert response.status_code == self.status_code
+        assert response.json() == self.json
+
+    def test_get_request(self):
+        res = self.session.get("/foo")
+        self._assert_response(res)
+
+    def test_post_request(self):
+        data = {"foo": "bar"}
+        res = self.session.post("/foo", json=data)
+        self._assert_response(res)
+
+    def test_put_request(self):
+        data = {"foo": "bar"}
+        res = self.session.put("/foo", json=data)
+        self._assert_response(res)


### PR DESCRIPTION
This PR changes the `StarmapClient` to allow injecting different sessions on it, as long as it follows the new `StarmapBaseSession` interface. With this, it's also possible to use an object of the new class `StarmapMockSession` in combination with a local provider to make the `StarmapClient` operate offline (only serving local mappings).

Changes:

- Add a mock session for Starmap Client
    
    This commit changes the `starmap_client.session` module with the
    following changes:
    
    - Introduce an interface called `StarmapBaseSession` which will be used
      to define the supported sessions for Starmap Client.
    
    - Implement a mock session class called `StarmapMockSession` which can
      be used in future to start an offline session in the Starmap Client.
      This will be particulary useful when combined with a local provider to
      avoid requesting data to the server in an isolated environment, like
      Konflux.

- Allow injecting custom session into StarmapClient
    
    This commit changes the `StarmapClient` to allow receiving a custom
    session which complies with the interface `StarmapBaseSession`.
    
    It also changes the `StarmapClient` signature to have `url` not required
    when the `session` is given by injection.
    
    This change is useful to use the `StarmapClient` in offline mode, it is,
    combined with a local provider in a scenario which network connection is
    not possible.
    
Refers to SPSTRAT-326 and SPSTRAT-327
