### PR TITLE
Replace Dependabot with  cd-red-bot 

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,0 @@
-version: 2
-updates:
-- package-ecosystem: pip
-  directory: /
-  schedule:
-    interval: monthly
-  allow:
-  - dependency-type: all

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -1,0 +1,41 @@
+on:
+    workflow_dispatch: {}
+    schedule:
+    - cron: "20 20 * * 0"
+  
+  name: "pip-compile: create PR"
+  jobs:
+   pip_compile:
+     name: pip-compile
+     runs-on: ubuntu-latest
+     steps:
+       - name: Setup Python
+         uses: actions/setup-python@v2
+         with:
+           python-version: "3.8"
+  
+       - name: Install system dependencies
+         run: |
+           sudo apt-get update
+           sudo apt-get install -y libkrb5-dev
+  
+       - name: Install tox
+         run: pip install tox
+  
+       - name: pip-compile
+         uses: technote-space/create-pr-action@v2
+         with:
+           EXECUTE_COMMANDS: tox -e pip-compile
+           COMMIT_MESSAGE: 'chore: scheduled pip-compile'
+           COMMIT_NAME: 'GitHub Actions'
+           COMMIT_EMAIL: 'noreply@github.com'
+           GITHUB_TOKEN: ${{ secrets.PIP_COMPILE_TOKEN }}
+           PR_BRANCH_PREFIX: deps/
+           PR_BRANCH_NAME: 'pip-compile'
+           PR_TITLE: 'chore: scheduled pip-compile'
+           PR_BODY: '## Update dependencies
+  
+    This is a scheduled update of Python dependencies within this repo managed by pip-compile.
+  
+    This change will be submitted automatically within a few days if all checks have
+    succeeded.'

--- a/tox.ini
+++ b/tox.ini
@@ -19,8 +19,8 @@ basepython = python3.8
 skip_install = true
 deps = pip-tools
 commands = 
-    pip-compile --generate-hashes --reuse-hashes --output-file=requirements.txt
-    pip-compile --generate-hashes --reuse-hashes --output-file=requirements-test.txt setup.py requirements-test.in
+    pip-compile -U --generate-hashes --reuse-hashes --output-file=requirements.txt
+    pip-compile -U --generate-hashes --reuse-hashes --output-file=requirements-test.txt setup.py requirements-test.in
 
 [testenv:docs]
 use_develop=true


### PR DESCRIPTION
This PR replaces the `dependabot` with a custom GH action which will constantly attempt to update the dependencies in a grouped way and open PRs through the [cd-red-bot](https://github.com/cd-red-bot), similarly to what is already being used by neighbor projects such as [pubtools-ami](https://github.com/release-engineering/pubtools-ami/blob/main/.github/workflows/pip-compile.yml)

With this we'll have the following advantages:

1. Automatically grouped updates
2. Dependencies being updated in the very same way we create/update the `requirements-*` without treating those files separately
3. More control on future automation (e.g. we can update it later to automatically approve/merge if everything is ok)