### PR TITLE
Automatically approve the chore deps if CI passess

### DIFF
--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -39,3 +39,19 @@ jobs:
 
   This change will be submitted automatically within a few days if all checks have
   succeeded.'
+
+     - name: Look up pull request
+       uses: juliangruber/find-pull-request-action@v1
+       id: find-pull-request
+       with:
+         branch: deps/pip-compile
+
+      # Immediately approve it if we can so it can be merged later
+     - name: Approve Pull Request
+       uses: juliangruber/approve-pull-request-action@v1
+       with:
+         github-token: ${{ secrets.APPROVAL_TOKEN }}
+         number: ${{ steps.find-pull-request.outputs.number }}
+       # allow errors because token may be unset.
+       continue-on-error: true
+       if: ${{ steps.find-pull-request.outputs.number }}


### PR DESCRIPTION
Automatically approve the chore deps if CI passess.

It uses the same implementation from `pubtools-ami`