### PR TITLE
Adds AMI templating for use in pubtools.

### DIFF
--- a/starmap_client/models.py
+++ b/starmap_client/models.py
@@ -168,6 +168,10 @@ class Destination(StarmapBaseData):
     restrict_minor: Optional[int] = field(validator=optional(instance_of(int)))
     """How many minor versions are allowed in product"""
 
+    ami_version_template: Optional[str] = field(validator=optional(instance_of(str)))
+    """Ami versioning template. Available options are major,minor,patch, or version.
+    Such as {major}.{minor}. If version is used it'll use the already available version."""
+
     provider: Optional[str] = field(validator=optional(instance_of(str)))
     """Represent the RHSM provider name for the community workflow."""
 

--- a/tests/data/destination/valid_dest1.json
+++ b/tests/data/destination/valid_dest1.json
@@ -1,7 +1,8 @@
 {
     "destination": "test-destination/foo/bar",
     "overwrite": false,
-    "restrict_version": false,
+    "restrict_version": true,
     "restrict_major": 1,
-    "restrict_minor": 1
+    "restrict_minor": 1,
+    "ami_version_template": "{major}.{minor}.{patch}"
 }


### PR DESCRIPTION
Adds AMI version templating. This is to allow one to set a template for the version used in the push_item name in pubtools-marketplacesvm. The options are major, minor, patch. Used such as {major}.{minor} which will be translated in pubtools-marketplacesvm for use in the name.