### PR TITLE
mypy: Few simple typing fixes

### DIFF
--- a/docs/ext/attr_index.py
+++ b/docs/ext/attr_index.py
@@ -63,6 +63,6 @@ def add_attr_index(
     lines.extend(["", ""])
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> None:
     # entrypoint invoked by sphinx when extension is loaded
     app.connect("autodoc-process-docstring", add_attr_index)

--- a/docs/ext/attr_types.py
+++ b/docs/ext/attr_types.py
@@ -53,6 +53,6 @@ def add_attr_types(
     lines.extend(["", f":type: {type.__name__}"])
 
 
-def setup(app: Sphinx):
+def setup(app: Sphinx) -> None:
     # entrypoint invoked by sphinx when extension is loaded
     app.connect("autodoc-process-docstring", add_attr_types)

--- a/starmap_client/models.py
+++ b/starmap_client/models.py
@@ -103,7 +103,7 @@ class StarmapJSONDecodeMixin:
         json = cls._preprocess_json(json)
 
         args = {}
-        cls_attr = [a.name for a in cls.__attrs_attrs__ if isinstance(a, Attribute)]  # type: ignore
+        cls_attr = [a.name for a in cls.__attrs_attrs__ if isinstance(a, Attribute)]
         for a in cls_attr:
             args[a] = json.pop(a, None)
         return cls(**args)

--- a/starmap_client/session.py
+++ b/starmap_client/session.py
@@ -124,7 +124,7 @@ class StarmapMockSession(StarmapSession):
         for m in methods:
             self.register_uri(m, re.compile(f"{base_url}/.*"))  # type: ignore [arg-type]
 
-    def register_uri(self, method: str, uri: str):
+    def register_uri(self, method: str, uri: str) -> None:
         """Register an URI into the ``requests_mock`` adapter.
 
         Args:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -22,7 +22,7 @@ def load_json(json_file: str) -> Any:
 
 class TestStarmapClient(TestCase):
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, caplog: LogCaptureFixture):
+    def inject_fixtures(self, caplog: LogCaptureFixture) -> None:
         self._caplog = caplog
 
     def setUp(self) -> None:
@@ -40,12 +40,12 @@ class TestStarmapClient(TestCase):
         self.mock_resp_success.status_code = 200
         self.mock_resp_not_found = mock.MagicMock()
         self.mock_resp_not_found.status_code = 404
-        self.mock_resp_not_found.raise_for_status.side_effect = HTTPError("Not found")  # type: ignore  # noqa: E501
+        self.mock_resp_not_found.raise_for_status.side_effect = HTTPError("Not found")  # noqa: E501
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         mock.patch.stopall()
 
-    def test_query_image_success_APIv2(self):
+    def test_query_image_success_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
         self.mock_resp_success.json.return_value = load_json(fpath)
         self.mock_session_v2.get.return_value = self.mock_resp_success
@@ -58,7 +58,7 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, QueryResponseContainer.from_json(load_json(fpath)))
 
-    def test_in_memory_query_image_APIv2(self):
+    def test_in_memory_query_image_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
         data = QueryResponseContainer.from_json(load_json(fpath))
         provider = InMemoryMapProviderV2(data)
@@ -68,7 +68,7 @@ class TestStarmapClient(TestCase):
         res = self.svc_v2.query_image("product-test-1.0-1.raw.xz", workflow="stratosphere")
         self.assertEqual(res.responses, [data.responses[0]])
 
-    def test_in_memory_api_mismatch(self):
+    def test_in_memory_api_mismatch(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
         data = QueryResponseContainer.from_json(load_json(fpath))
         provider_v2 = InMemoryMapProviderV2(data)
@@ -77,7 +77,7 @@ class TestStarmapClient(TestCase):
         with pytest.raises(ValueError, match=err):
             StarmapClient("foo", api_version="v1", provider=provider_v2)
 
-    def test_query_image_not_found(self):
+    def test_query_image_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
 
@@ -88,7 +88,7 @@ class TestStarmapClient(TestCase):
                 assert expected_msg in self._caplog.text
                 self.assertIsNone(res)
 
-    def test_query_image_by_name_APIv2(self):
+    def test_query_image_by_name_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
         self.mock_resp_success.json.return_value = load_json(fpath)
         self.mock_session_v2.get.return_value = self.mock_resp_success
@@ -101,7 +101,7 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, QueryResponseContainer.from_json(load_json(fpath)))
 
-    def test_in_memory_query_image_by_name_APIv2(self):
+    def test_in_memory_query_image_by_name_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
         data = QueryResponseContainer.from_json(load_json(fpath))
         provider = InMemoryMapProviderV2(data)
@@ -112,7 +112,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_not_called()
         self.assertEqual(res.responses, [data.responses[0]])
 
-    def test_query_image_by_name_version_APIv2(self):
+    def test_query_image_by_name_version_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
         self.mock_resp_success.json.return_value = load_json(fpath)
         self.mock_session_v2.get.return_value = self.mock_resp_success
@@ -128,7 +128,7 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, QueryResponseContainer.from_json(load_json(fpath)))
 
-    def test_policies_single_page(self):
+    def test_policies_single_page(self) -> None:
         fpath = "tests/data/policy/valid_pol1.json"
         single_page = {
             "items": [load_json(fpath)],
@@ -157,7 +157,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.call_count == 1
         self.mock_resp_success.raise_for_status.assert_called_once()
 
-    def test_policies_multi_page(self):
+    def test_policies_multi_page(self) -> None:
         fpath = "tests/data/policy/valid_pol1.json"
         page1 = {
             "items": [load_json(fpath)],
@@ -196,7 +196,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.call_count == 2
         self.mock_resp_success.raise_for_status.call_count == 2
 
-    def test_policies_not_found(self):
+    def test_policies_not_found(self) -> None:
         self.svc_v2.POLICIES_PER_PAGE = 1
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
 
@@ -206,7 +206,7 @@ class TestStarmapClient(TestCase):
         assert "No policies registered in StArMap." in self._caplog.text
 
     @mock.patch('starmap_client.StarmapClient.policies')
-    def test_list_policies(self, mock_policies: mock.MagicMock):
+    def test_list_policies(self, mock_policies: mock.MagicMock) -> None:
         fpath = "tests/data/policy/valid_pol1.json"
         pol = Policy.from_json(load_json(fpath))
         pol_list = [pol]
@@ -224,7 +224,7 @@ class TestStarmapClient(TestCase):
         mock_policies.__iter__.assert_called_once()
         self.assertEqual(res, pol_list)
 
-    def test_get_policy(self):
+    def test_get_policy(self) -> None:
         fpath = "tests/data/policy/valid_pol1.json"
         self.mock_resp_success.json.return_value = load_json(fpath)
         self.mock_session_v2.get.return_value = self.mock_resp_success
@@ -236,7 +236,7 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, Policy.from_json(load_json(fpath)))
 
-    def test_get_policy_not_found(self):
+    def test_get_policy_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
 
         with self._caplog.at_level(logging.ERROR):
@@ -267,7 +267,7 @@ class TestStarmapClient(TestCase):
 
         self.assertEqual(res, [])
 
-    def test_get_mapping(self):
+    def test_get_mapping(self) -> None:
         fpath = "tests/data/mapping/valid_map1.json"
         self.mock_resp_success.json.return_value = load_json(fpath)
         self.mock_session_v2.get.return_value = self.mock_resp_success
@@ -279,7 +279,7 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, Mapping.from_json(load_json(fpath)))
 
-    def test_get_mapping_not_found(self):
+    def test_get_mapping_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
 
         with self._caplog.at_level(logging.ERROR):
@@ -310,7 +310,7 @@ class TestStarmapClient(TestCase):
 
         self.assertEqual(res, [])
 
-    def test_get_destination(self):
+    def test_get_destination(self) -> None:
         fpath = "tests/data/destination/valid_dest1.json"
         self.mock_resp_success.json.return_value = load_json(fpath)
         self.mock_session_v2.get.return_value = self.mock_resp_success
@@ -322,7 +322,7 @@ class TestStarmapClient(TestCase):
         # Note: JSON need to be loaded twice as `from_json` pops its original data
         self.assertEqual(res, Destination.from_json(load_json(fpath)))
 
-    def test_get_destination_not_found(self):
+    def test_get_destination_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
 
         with self._caplog.at_level(logging.ERROR):
@@ -333,13 +333,13 @@ class TestStarmapClient(TestCase):
 
         self.assertIsNone(res)
 
-    def test_client_requires_url_or_session(self):
+    def test_client_requires_url_or_session(self) -> None:
         error = "Cannot initialize the client without defining either an \"url\" or \"session\"."
         with pytest.raises(ValueError, match=error):
             StarmapClient()
 
 
-def test_offline_client():
+def test_offline_client() -> None:
     """Ensure the cient can be used offline with a local provider."""
     fpath = "tests/data/query_v2/query_response_container/valid_qrc2.json"
     qrc = QueryResponseContainer.from_json(load_json(fpath))

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -66,6 +66,7 @@ class TestStarmapClient(TestCase):
         self.svc_v2 = StarmapClient("https://test.starmap.com", api_version="v2", provider=provider)
 
         res = self.svc_v2.query_image("product-test-1.0-1.raw.xz", workflow="stratosphere")
+        assert res
         assert res.responses == [data.responses[0]]
 
     def test_in_memory_api_mismatch(self) -> None:
@@ -109,6 +110,7 @@ class TestStarmapClient(TestCase):
         self.svc_v2 = StarmapClient("https://test.starmap.com", api_version="v2", provider=provider)
 
         res = self.svc_v2.query_image_by_name(name="product-test", workflow="stratosphere")
+        assert res
         self.mock_session_v2.get.assert_not_called()
         assert res.responses == [data.responses[0]]
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -40,7 +40,9 @@ class TestStarmapClient(TestCase):
         self.mock_resp_success.status_code = 200
         self.mock_resp_not_found = mock.MagicMock()
         self.mock_resp_not_found.status_code = 404
-        self.mock_resp_not_found.raise_for_status.side_effect = HTTPError("Not found")  # noqa: E501
+        self.mock_resp_not_found.raise_for_status.side_effect = HTTPError(
+            "Not found", response=self.mock_resp_not_found
+        )
 
     def tearDown(self) -> None:
         mock.patch.stopall()
@@ -175,8 +177,8 @@ class TestStarmapClient(TestCase):
             },
         }
         page2 = deepcopy(page1)
-        page2["nav"]["next"] = None
-        page2["nav"]["page"] = 2
+        page2["nav"]["next"] = None  # type: ignore[index]
+        page2["nav"]["page"] = 2  # type: ignore[index]
         self.svc_v2.POLICIES_PER_PAGE = 1
         self.mock_resp_success.json.side_effect = [page1, page2]
         self.mock_session_v2.get.return_value = self.mock_resp_success

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -56,7 +56,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_called_once_with("/query", params=expected_params)
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
-        self.assertEqual(res, QueryResponseContainer.from_json(load_json(fpath)))
+        assert res == QueryResponseContainer.from_json(load_json(fpath))
 
     def test_in_memory_query_image_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
@@ -66,7 +66,7 @@ class TestStarmapClient(TestCase):
         self.svc_v2 = StarmapClient("https://test.starmap.com", api_version="v2", provider=provider)
 
         res = self.svc_v2.query_image("product-test-1.0-1.raw.xz", workflow="stratosphere")
-        self.assertEqual(res.responses, [data.responses[0]])
+        assert res.responses == [data.responses[0]]
 
     def test_in_memory_api_mismatch(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
@@ -86,7 +86,7 @@ class TestStarmapClient(TestCase):
                 res = svc.query_image(self.image)
                 expected_msg = "Marketplace mappings not defined for {'image': '%s'}" % self.image
                 assert expected_msg in self._caplog.text
-                self.assertIsNone(res)
+                assert res is None
 
     def test_query_image_by_name_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
@@ -99,7 +99,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_called_once_with("/query", params=expected_params)
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
-        self.assertEqual(res, QueryResponseContainer.from_json(load_json(fpath)))
+        assert res == QueryResponseContainer.from_json(load_json(fpath))
 
     def test_in_memory_query_image_by_name_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
@@ -110,7 +110,7 @@ class TestStarmapClient(TestCase):
 
         res = self.svc_v2.query_image_by_name(name="product-test", workflow="stratosphere")
         self.mock_session_v2.get.assert_not_called()
-        self.assertEqual(res.responses, [data.responses[0]])
+        assert res.responses == [data.responses[0]]
 
     def test_query_image_by_name_version_APIv2(self) -> None:
         fpath = "tests/data/query_v2/query_response_container/valid_qrc1.json"
@@ -126,7 +126,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_called_once_with("/query", params=expected_params)
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
-        self.assertEqual(res, QueryResponseContainer.from_json(load_json(fpath)))
+        assert res == QueryResponseContainer.from_json(load_json(fpath))
 
     def test_policies_single_page(self) -> None:
         fpath = "tests/data/policy/valid_pol1.json"
@@ -150,7 +150,7 @@ class TestStarmapClient(TestCase):
         # Iterate over all policies from StarmapClient property and
         # ensure each of them has a valid format.
         for p in self.svc_v2.policies:
-            self.assertEqual(p, Policy.from_json(load_json(fpath)))
+            assert p == Policy.from_json(load_json(fpath))
 
         expected_params = {"page": 1, "per_page": 1}
         self.mock_session_v2.get.assert_called_once_with("policy", params=expected_params)
@@ -182,7 +182,7 @@ class TestStarmapClient(TestCase):
         # Iterate over all policies from StarmapClient property and
         # ensure each of them has a valid format.
         for p in self.svc_v2.policies:
-            self.assertEqual(p, Policy.from_json(load_json(fpath)))
+            assert p == Policy.from_json(load_json(fpath))
 
         get_calls = [
             mock.call("policy", params={"page": 1, "per_page": 1}),
@@ -216,13 +216,13 @@ class TestStarmapClient(TestCase):
         self.svc_v2._policies = pol_list
         res = self.svc_v2.list_policies()
         mock_policies.__iter__.assert_not_called()
-        self.assertEqual(res, self.svc_v2._policies)
+        assert res == self.svc_v2._policies
 
         # Test uncached policies list
         self.svc_v2._policies = []
         res = self.svc_v2.list_policies()
         mock_policies.__iter__.assert_called_once()
-        self.assertEqual(res, pol_list)
+        assert res == pol_list
 
     def test_get_policy(self) -> None:
         fpath = "tests/data/policy/valid_pol1.json"
@@ -234,7 +234,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_called_once_with("/policy/policy-id")
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
-        self.assertEqual(res, Policy.from_json(load_json(fpath)))
+        assert res == Policy.from_json(load_json(fpath))
 
     def test_get_policy_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
@@ -245,7 +245,7 @@ class TestStarmapClient(TestCase):
         expected_msg = "Policy not found with ID = \"policy-id\""
         assert expected_msg in self._caplog.text
 
-        self.assertIsNone(res)
+        assert res is None
 
     @mock.patch("starmap_client.StarmapClient.get_policy")
     def test_list_mappings(self, mock_get_policy: mock.MagicMock) -> None:
@@ -256,7 +256,7 @@ class TestStarmapClient(TestCase):
         res = self.svc_v2.list_mappings(policy_id="policy-id")
 
         mock_get_policy.assert_called_once_with("policy-id")
-        self.assertEqual(res, p.mappings)
+        assert res == p.mappings
 
     @mock.patch("starmap_client.StarmapClient.get_policy")
     def test_list_mappings_not_found(self, mock_get_policy: mock.MagicMock) -> None:
@@ -265,7 +265,7 @@ class TestStarmapClient(TestCase):
 
         mock_get_policy.assert_called_once_with("policy-id")
 
-        self.assertEqual(res, [])
+        assert res == []
 
     def test_get_mapping(self) -> None:
         fpath = "tests/data/mapping/valid_map1.json"
@@ -277,7 +277,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_called_once_with("/mapping/mapping-id")
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
-        self.assertEqual(res, Mapping.from_json(load_json(fpath)))
+        assert res == Mapping.from_json(load_json(fpath))
 
     def test_get_mapping_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
@@ -288,7 +288,7 @@ class TestStarmapClient(TestCase):
         expected_msg = "Marketplace Mapping not found with ID = \"mapping-id\""
         assert expected_msg in self._caplog.text
 
-        self.assertIsNone(res)
+        assert res is None
 
     @mock.patch("starmap_client.StarmapClient.get_mapping")
     def test_list_destinations(self, mock_get_mapping: mock.MagicMock) -> None:
@@ -299,7 +299,7 @@ class TestStarmapClient(TestCase):
         res = self.svc_v2.list_destinations(mapping_id="mapping-id")
 
         mock_get_mapping.assert_called_once_with("mapping-id")
-        self.assertEqual(res, m.destinations)
+        assert res == m.destinations
 
     @mock.patch("starmap_client.StarmapClient.get_mapping")
     def test_list_destinations_not_found(self, mock_get_mapping: mock.MagicMock) -> None:
@@ -308,7 +308,7 @@ class TestStarmapClient(TestCase):
 
         mock_get_mapping.assert_called_once_with("mapping-id")
 
-        self.assertEqual(res, [])
+        assert res == []
 
     def test_get_destination(self) -> None:
         fpath = "tests/data/destination/valid_dest1.json"
@@ -320,7 +320,7 @@ class TestStarmapClient(TestCase):
         self.mock_session_v2.get.assert_called_once_with("/destination/destination-id")
         self.mock_resp_success.raise_for_status.assert_called_once()
         # Note: JSON need to be loaded twice as `from_json` pops its original data
-        self.assertEqual(res, Destination.from_json(load_json(fpath)))
+        assert res == Destination.from_json(load_json(fpath))
 
     def test_get_destination_not_found(self) -> None:
         self.mock_session_v2.get.return_value = self.mock_resp_not_found
@@ -331,7 +331,7 @@ class TestStarmapClient(TestCase):
         expected_msg = "Destination not found with ID = \"destination-id\""
         assert expected_msg in self._caplog.text
 
-        self.assertIsNone(res)
+        assert res is None
 
     def test_client_requires_url_or_session(self) -> None:
         error = "Cannot initialize the client without defining either an \"url\" or \"session\"."

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,6 +1,6 @@
 import json
 from copy import deepcopy
-from typing import Any
+from typing import Any, Optional
 
 import pytest
 from attrs import asdict
@@ -63,14 +63,14 @@ class TestDestination:
         with pytest.raises(TypeError, match=err):
             Destination.from_json(data)
 
-    def test_parse_json_not_dict(self):
+    def test_parse_json_not_dict(self) -> None:
         fake_json = ["I", "am", "a", "list"]
         err = "Got an unsupported JSON type: \"<class 'list'>\". Expected: \"<class 'dict'>\'"
 
         with pytest.raises(ValueError, match=err):
             Destination.from_json(fake_json)
 
-    def test_invalid_meta(self):
+    def test_invalid_meta(self) -> None:
         data = load_json("tests/data/destination/valid_dest1.json")
 
         # Test invalid `meta` type
@@ -86,7 +86,7 @@ class TestDestination:
         with pytest.raises(ValueError, match=err):
             Destination.from_json(data)
 
-    def test_frozen_destination(self):
+    def test_frozen_destination(self) -> None:
         data = load_json("tests/data/destination/valid_dest1.json")
 
         d = Destination.from_json(data)
@@ -134,7 +134,7 @@ class TestMapping:
         with pytest.raises((TypeError, ValueError)):
             Mapping.from_json(data)
 
-    def test_frozen_mapping(self):
+    def test_frozen_mapping(self) -> None:
         data = load_json("tests/data/mapping/valid_map1.json")
 
         m = Mapping.from_json(data)
@@ -182,7 +182,7 @@ class TestPolicy:
         with pytest.raises((TypeError, ValueError)):
             Policy.from_json(data)
 
-    def test_frozen_policy(self):
+    def test_frozen_policy(self) -> None:
         data = load_json("tests/data/policy/valid_pol1.json")
 
         p = Policy.from_json(data)
@@ -217,7 +217,9 @@ class TestV2MappingResponseObject:
             ),
         ],
     )
-    def test_valid_mapping_response_obj(self, json_file, meta, provider) -> None:
+    def test_valid_mapping_response_obj(
+        self, json_file: str, meta: str, provider: Optional[str]
+    ) -> None:
         data = load_json(json_file)
         expected_meta = load_json(meta)
 
@@ -235,7 +237,7 @@ class TestV2MappingResponseObject:
             "tests/data/query_v2/mapping_response_obj/invalid_mro3.json",
         ],
     )
-    def test_invalid_clouds(self, json_file) -> None:
+    def test_invalid_clouds(self, json_file: str) -> None:
         data = load_json(json_file)
         err = data.pop("error")
 
@@ -269,7 +271,7 @@ class TestV2QueryResponseEntity:
             ),
         ],
     )
-    def test_valid_query_response_entity(self, json_file, meta) -> None:
+    def test_valid_query_response_entity(self, json_file: str, meta: str) -> None:
         data = load_json(json_file)
         d = deepcopy(data)
         expected_meta_dict = load_json(meta)
@@ -308,7 +310,7 @@ class TestV2QueryResponseContainer:
     @pytest.mark.parametrize(
         "json_file", ["tests/data/query_v2/query_response_container/invalid_qrc1.json"]
     )
-    def test_invalid_query_response_container(self, json_file) -> None:
+    def test_invalid_query_response_container(self, json_file: str) -> None:
         data = load_json(json_file)
         err = f"Expected root to be a list, got \"{type(data)}\""
         with pytest.raises(ValueError, match=err):

--- a/tests/test_providers/conftest.py
+++ b/tests/test_providers/conftest.py
@@ -83,20 +83,20 @@ def qre2() -> Dict[str, Any]:
 
 
 @pytest.fixture
-def qrc(qre1, qre2) -> List[Dict[str, Any]]:
+def qrc(qre1: Dict[str, Any], qre2: Dict[str, Any]) -> List[Dict[str, Any]]:
     return [deepcopy(qre1), deepcopy(qre2)]
 
 
 @pytest.fixture
-def qre1_object(qre1) -> QueryResponseEntity:
+def qre1_object(qre1: Any) -> QueryResponseEntity:
     return QueryResponseEntity.from_json(deepcopy(qre1))
 
 
 @pytest.fixture
-def qre2_object(qre2) -> QueryResponseEntity:
+def qre2_object(qre2: Any) -> QueryResponseEntity:
     return QueryResponseEntity.from_json(deepcopy(qre2))
 
 
 @pytest.fixture
-def qrc_object(qrc) -> QueryResponseContainer:
+def qrc_object(qrc: Any) -> QueryResponseContainer:
     return QueryResponseContainer.from_json(qrc)

--- a/tests/test_providers/test_utils.py
+++ b/tests/test_providers/test_utils.py
@@ -3,79 +3,73 @@
 # https://github.com/release-engineering/kobo/blob/master/tests/test_rpmlib.py
 import unittest
 
+import pytest
+
 from starmap_client.providers.utils import get_image_name, parse_nvr
 
 
 class TestNVR(unittest.TestCase):
     def test_parse_nvr_success(self) -> None:
-        self.assertEqual(
-            parse_nvr("net-snmp-5.3.2.2-5.el5"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch=""),
+        assert parse_nvr("net-snmp-5.3.2.2-5.el5") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch=""
         )
-        self.assertEqual(
-            parse_nvr("1:net-snmp-5.3.2.2-5.el5"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("1:net-snmp-5.3.2.2-5.el5") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("net-snmp-1:5.3.2.2-5.el5"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("net-snmp-1:5.3.2.2-5.el5") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("net-snmp-5.3.2.2-5.el5:1"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("net-snmp-5.3.2.2-5.el5:1") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("/net-snmp-5.3.2.2-5.el5:1"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("/net-snmp-5.3.2.2-5.el5:1") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("/1:net-snmp-5.3.2.2-5.el5"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("/1:net-snmp-5.3.2.2-5.el5") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("foo/net-snmp-5.3.2.2-5.el5:1"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("foo/net-snmp-5.3.2.2-5.el5:1") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("foo/1:net-snmp-5.3.2.2-5.el5"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("foo/1:net-snmp-5.3.2.2-5.el5") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("/foo/bar/net-snmp-5.3.2.2-5.el5:1"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("/foo/bar/net-snmp-5.3.2.2-5.el5:1") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
-        self.assertEqual(
-            parse_nvr("/foo/bar/1:net-snmp-5.3.2.2-5.el5"),
-            dict(name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"),
+        assert parse_nvr("/foo/bar/1:net-snmp-5.3.2.2-5.el5") == dict(
+            name="net-snmp", version="5.3.2.2", release="5.el5", epoch="1"
         )
 
         # test for name which contains the version number and a dash
-        self.assertEqual(
-            parse_nvr("openmpi-1.10-1.10.2-2.el6"),
-            dict(name="openmpi-1.10", version="1.10.2", release="2.el6", epoch=""),
+        assert parse_nvr("openmpi-1.10-1.10.2-2.el6") == dict(
+            name="openmpi-1.10", version="1.10.2", release="2.el6", epoch=""
         )
 
     def test_parse_nvr_invalid(self) -> None:
-        self.assertRaises(RuntimeError, parse_nvr, "net-snmp")
-        self.assertRaises(RuntimeError, parse_nvr, "net-snmp-5.3.2.2-1:5.el5")
-        self.assertRaises(RuntimeError, parse_nvr, "1:net-snmp-5.3.2.2-5.el5:1")
-        self.assertRaises(RuntimeError, parse_nvr, "1:net-snmp-1:5.3.2.2-5.el5")
-        self.assertRaises(RuntimeError, parse_nvr, "net-snmp-1:5.3.2.2-5.el5:1")
-        self.assertRaises(RuntimeError, parse_nvr, "1:net-snmp-1:5.3.2.2-5.el5:1")
+        with pytest.raises(RuntimeError):
+            parse_nvr("net-snmp")
+        with pytest.raises(RuntimeError):
+            parse_nvr("net-snmp-5.3.2.2-1:5.el5")
+        with pytest.raises(RuntimeError):
+            parse_nvr("1:net-snmp-5.3.2.2-5.el5:1")
+        with pytest.raises(RuntimeError):
+            parse_nvr("1:net-snmp-1:5.3.2.2-5.el5")
+        with pytest.raises(RuntimeError):
+            parse_nvr("net-snmp-1:5.3.2.2-5.el5:1")
+        with pytest.raises(RuntimeError):
+            parse_nvr("1:net-snmp-1:5.3.2.2-5.el5:1")
 
     def test_get_image_name(self) -> None:
-        self.assertEqual(get_image_name("net-snmp-5.3.2.2-5.el5"), "net-snmp")
-        self.assertEqual(get_image_name("1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
-        self.assertEqual(get_image_name("net-snmp-1:5.3.2.2-5.el5"), "net-snmp")
-        self.assertEqual(get_image_name("net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
-        self.assertEqual(get_image_name("/net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
-        self.assertEqual(get_image_name("/1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
-        self.assertEqual(get_image_name("foo/net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
-        self.assertEqual(get_image_name("foo/1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
-        self.assertEqual(get_image_name("/foo/bar/net-snmp-5.3.2.2-5.el5:1"), "net-snmp")
-        self.assertEqual(get_image_name("/foo/bar/1:net-snmp-5.3.2.2-5.el5"), "net-snmp")
-        self.assertEqual(
-            get_image_name("openmpi-1.10-1.10.2-2.el6"),
-            "openmpi-1.10",
-        )
-        self.assertEqual(get_image_name(None), "")
+        assert get_image_name("net-snmp-5.3.2.2-5.el5") == "net-snmp"
+        assert get_image_name("1:net-snmp-5.3.2.2-5.el5") == "net-snmp"
+        assert get_image_name("net-snmp-1:5.3.2.2-5.el5") == "net-snmp"
+        assert get_image_name("net-snmp-5.3.2.2-5.el5:1") == "net-snmp"
+        assert get_image_name("/net-snmp-5.3.2.2-5.el5:1") == "net-snmp"
+        assert get_image_name("/1:net-snmp-5.3.2.2-5.el5") == "net-snmp"
+        assert get_image_name("foo/net-snmp-5.3.2.2-5.el5:1") == "net-snmp"
+        assert get_image_name("foo/1:net-snmp-5.3.2.2-5.el5") == "net-snmp"
+        assert get_image_name("/foo/bar/net-snmp-5.3.2.2-5.el5:1") == "net-snmp"
+        assert get_image_name("/foo/bar/1:net-snmp-5.3.2.2-5.el5") == "net-snmp"
+        assert get_image_name("openmpi-1.10-1.10.2-2.el6") == "openmpi-1.10"
+        assert get_image_name(None) == ""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,10 +1,13 @@
+from typing import Any, Dict
 from unittest import TestCase, mock
+
+import requests
 
 from starmap_client.session import StarmapMockSession, StarmapSession
 
 
 class TestStarmapSession(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.starmap_url = "test.starmap.com"
         self.starmap_api_version = "v1"
         self.session = StarmapSession(url=self.starmap_url, api_version=self.starmap_api_version)
@@ -12,7 +15,7 @@ class TestStarmapSession(TestCase):
         # Mock requests.Session()
         self.mock_requests = mock.patch.object(self.session, 'session').start()
 
-    def _assert_requested_with(self, method, path, **kwargs):
+    def _assert_requested_with(self, method: str, path: str, **kwargs) -> None:
         headers = {
             "Accept": "application/json",
         }
@@ -25,27 +28,27 @@ class TestStarmapSession(TestCase):
             **kwargs,
         )
 
-    def test_get_request(self):
+    def test_get_request(self) -> None:
         self.session.get("/foo")
         self._assert_requested_with(method="get", path="foo")
 
-    def test_post_request(self):
+    def test_post_request(self) -> None:
         data = {"foo": "bar"}
         self.session.post("/foo", json=data)
         self._assert_requested_with(method="post", path="foo", json=data)
 
-    def test_put_request(self):
+    def test_put_request(self) -> None:
         data = {"foo": "bar"}
         self.session.put("/foo", json=data)
         self._assert_requested_with(method="put", path="foo", json=data)
 
 
 class TestMockSession(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.starmap_url = "test.starmap.com"
         self.starmap_api_version = "v1"
         self.status_code = 404
-        self.json = {}
+        self.json: Dict[str, Any] = {}
         self.session = StarmapMockSession(
             url=self.starmap_url,
             api_version=self.starmap_api_version,
@@ -53,20 +56,20 @@ class TestMockSession(TestCase):
             json_data=self.json,
         )
 
-    def _assert_response(self, response):
+    def _assert_response(self, response: requests.Response) -> None:
         assert response.status_code == self.status_code
         assert response.json() == self.json
 
-    def test_get_request(self):
+    def test_get_request(self) -> None:
         res = self.session.get("/foo")
         self._assert_response(res)
 
-    def test_post_request(self):
+    def test_post_request(self) -> None:
         data = {"foo": "bar"}
         res = self.session.post("/foo", json=data)
         self._assert_response(res)
 
-    def test_put_request(self):
+    def test_put_request(self) -> None:
         data = {"foo": "bar"}
         res = self.session.put("/foo", json=data)
         self._assert_response(res)

--- a/tox.ini
+++ b/tox.ini
@@ -37,9 +37,9 @@ deps =
     isort
     mypy
 commands = 
-    flake8 --max-line-length=100 --ignore=D100,D104,D105 --per-file-ignores=tests/*:D101,D102,D103 starmap_client tests
-    black -S -t py39 -l 100 --check --diff starmap_client tests
     isort -l 100 --profile black --check --diff starmap_client tests
+    black -S -t py39 -l 100 --check --diff starmap_client tests
+    flake8 --max-line-length=100 --ignore=D100,D104,D105 --per-file-ignores=tests/*:D101,D102,D103 starmap_client tests
 
 [testenv:mypy]
 basepython = python3.9


### PR DESCRIPTION
and also
* Change order of linters
    black and idiff log diff which need to be applied.
    flak8 does not report diff but can report similar issues.
  
*   tests: Use plain assert-statements instead of self.assert* functions
Mypy ignored `self.assertIsNotNone` and still reported failure `Item "None" of "Optional[QueryResponseContainer]" has no attribute "responses"  [union-attr]`

Tests were automatically converted using:  `unittest2pytest -f self_assert -w tests/`