### PR TITLE
Pin PIP version for pip-compile job

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,9 @@ commands=
 [testenv:pip-compile]
 basepython = python3.9
 skip_install = true
-deps = pip-tools
+deps =
+    pip-tools
+    pip==22.0.0
 commands = 
     pip-compile -U --generate-hashes --reuse-hashes --output-file=requirements.txt
     pip-compile -U --allow-unsafe --generate-hashes --reuse-hashes --output-file=requirements-test.txt setup.py requirements-test.in


### PR DESCRIPTION
This commit pins `pip==22.0.0` in the `tox` environment `pip-compile` as later versions of it are not properly working, causing the following failure when running the scheduled CI via GH Actions:

```
AttributeError: 'function' object has no attribute 'cache_clear'
```