### PR TITLE
Update package name to be compliant with PEP625

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 
 setup(
-    name='starmap-client',
+    name='starmap_client',
     description='Client for StArMap',
     version='2.3.0',
     keywords='stratosphere content artifact mapping cli',


### PR DESCRIPTION
From PyPI:

```
This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'starmap-client'.

In the future, PyPI will require all newly uploaded source distribution filenames to comply with PEP 625. Any source distributions already uploaded will remain in place as-is and do not need to be updated.

Specifically, your recent upload of 'starmap-client-2.3.0.tar.gz' is incompatible with PEP 625 because the filename does not contain the normalized project name 'starmap_client'.

In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. You do not need to remove the file.

If you have questions, you can email admin@pypi.org to communicate with the PyPI admin@pypi.org to communicate with the PyPI administrators.
```