### PR TITLE
OWASP Check: Add OSS username/passwd

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -117,6 +117,8 @@ jobs:
           --out "dependency-check" \
           --format "ALL" \
           --nvdApiKey ${{ secrets.OWASP_API_KEY }} \
+          --ossIndexUsername ${{ secrets.OSS_INDEX_USERNAME }} \
+          --ossIndexPassword ${{ secrets.OSS_INDEX_PASSWORD }} \
           --enableExperimental \
           --scan . \
           --data .code_scanning/dependency-check/data \


### PR DESCRIPTION
This commit adds the OSS username and password to fix failures on `security` Job during the OWASP check execution.

Refers to SPSTRAT-614

## Summary by Sourcery

CI:
- Pass OSS_INDEX_USERNAME and OSS_INDEX_PASSWORD secrets to the dependency-check command in the tox-test workflow