### PR TITLE
Revert "Drop support for python 3.9"

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install OS packages
         run: |
           sudo apt-get -y update

--- a/.github/workflows/pip-compile.yml
+++ b/.github/workflows/pip-compile.yml
@@ -12,7 +12,7 @@ jobs:
      - name: Setup Python
        uses: actions/setup-python@v6
        with:
-         python-version: "3.10"
+         python-version: "3.9"
 
      - name: Install system dependencies
        run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,7 +13,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v6
       with:
-        python-version: '3.10'
+        python-version: '3.9'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run Linting
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run MyPy
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         # https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
     steps:
       - uses: actions/checkout@v6
       - name: Set up Python ${{ matrix.python-version }}
@@ -72,7 +72,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Install pytest cov
@@ -91,7 +91,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox
       - name: Run Tox
@@ -176,7 +176,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.10"
+          python-version: 3.9
       - name: Install Tox
         run: pip install tox 'virtualenv<20.21.1'
       - name: Run Tox

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ used by [release-engineering](https://github.com/release-engineering) publishing
 
 The `StArMap Client` is a client library to communicate with the _StArMap_ service, which is used to map a VM image build to its respective cloud marketplace(s) destination(s).
 
-It's written to support applications running on `Python >= 3.10`.
+It's written to support applications running on `Python >= 3.9`.
 
 This library has a minimum set of requirements (namely `attrs` and `requests`) and can be installed and used in any supported environment.
 
@@ -62,7 +62,7 @@ Querying the destinations of an image:
 
 The versions listed below are the one which were tested and work. Other versions can work as well.
 
-- Install or create a `virtualenv` for `python` >= 3.10
+- Install or create a `virtualenv` for `python` >= 3.9
 - Install `tox` >= 3.25
 
 ### Dependency Management

--- a/requirements-test.in
+++ b/requirements-test.in
@@ -5,5 +5,5 @@ pytest
 pytest-cov
 sphinx
 sphinx-autodoc-typehints
-types-requests
+types-requests<=2.31.0.6
 types-setuptools

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     include_package_data=True,
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
         'Programming Language :: Python :: 3.11',
         'Programming Language :: Python :: 3.12',
@@ -24,7 +25,7 @@ setup(
         'attrs',
         'requests',
         'requests_mock',
-        'urllib3',
+        'urllib3<2.0.0'
     ],
     zip_safe=False,
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pip-compile, docs, lint, mypy, security, py310, py311, py312, py313
+envlist = pip-compile, docs, lint, mypy, security, py39, py310, py311, py312, py313
 
 [testenv]
 envdir = {toxworkdir}/shared-environment
@@ -15,7 +15,7 @@ commands=
         --cov-report xml --cov-report html {posargs}
 
 [testenv:pip-compile]
-basepython = python3.10
+basepython = python3.9
 skip_install = true
 deps =
     pip-tools
@@ -25,7 +25,7 @@ commands =
     pip-compile -U --allow-unsafe --generate-hashes --reuse-hashes --output-file=requirements-test.txt setup.py requirements-test.in
 
 [testenv:docs]
-basepython = python3.10
+basepython = python3.9
 use_develop=true
 commands=
 	sphinx-build -M html docs docs/_build
@@ -40,11 +40,11 @@ deps =
     mypy
 commands = 
     isort -l 100 --profile black --check --diff starmap_client tests
-    black -S -t py310 -l 100 --check --diff starmap_client tests
+    black -S -t py39 -l 100 --check --diff starmap_client tests
     flake8 --max-line-length=100 --ignore=D100,D104,D105 --per-file-ignores=tests/*:D101,D102,D103 starmap_client tests
 
 [testenv:mypy]
-basepython = python3.10
+basepython = python3.9
 deps = -r requirements-test.txt
 commands = mypy --show-error-codes --strict --warn-unused-configs --warn-unused-ignores --warn-redundant-casts --warn-unreachable --exclude '^venv.*' .
 
@@ -70,7 +70,7 @@ commands =
     isort -l 100 --profile black starmap_client tests
 
 [testenv:coverage]
-basepython = python3.10
+basepython = python3.9
 deps = -r requirements-test.txt
 relative_files = True
 usedevelop= True


### PR DESCRIPTION
This reverts commit cc81ebda2b1826cb77d421ed4049512bfc5aba00.

## Summary by Sourcery

Restore support for Python 3.9 across the project, including tooling, CI, and packaging metadata.

Enhancements:
- Reconfigure tox environments to add a py39 env and use Python 3.9 as the base interpreter for linting, docs, mypy, and coverage tasks.

Build:
- Update packaging metadata to declare Python 3.9 support and pin urllib3 to a Python 3.9–compatible version.

CI:
- Adjust GitHub Actions workflows to run tox, docs, tests, and release jobs on Python 3.9 and extend the test matrix to include 3.9.

Documentation:
- Update README to state Python 3.9 as the minimum supported version and reflect this in local setup instructions.