### PR TITLE
tox: drop safety in favor of pip-audit only

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -52,11 +52,9 @@ commands = mypy --show-error-codes --strict --warn-unused-configs --warn-unused-
 skip_install = true
 deps = 
     bandit
-    safety
     pip-audit
 commands = 
     bandit -s B303 -r starmap_client
-    safety check -r requirements.txt
     pip-audit -S -s pypi --index-url {env:PIP_INDEX_URL} -r requirements.txt
     pip-audit -S -s osv --index-url {env:PIP_INDEX_URL} -r requirements.txt
 


### PR DESCRIPTION
tox: drop safety in favor of pip-audit only

## Summary by Sourcery

Build:
- Remove the safety dependency and its check command from the security tox environment configuration.