### PR TITLE
fix: use the permissions & environment for PyPI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    environment: pypi
     steps:
     - uses: actions/checkout@v7
     - name: Set up Python


### PR DESCRIPTION
Fix the release action to use the missing environment and permissions to push to PyPI

## Summary by Sourcery

CI:
- Grant the release job id-token write permission and associate it with the pypi environment in the GitHub Actions workflow.